### PR TITLE
reduced number of samples in each experiment

### DIFF
--- a/04-services.ipynb
+++ b/04-services.ipynb
@@ -176,7 +176,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "experiment(data, 100000, fraud=.02, legitimate=.98)"
+    "experiment(data, 1000, fraud=.02, legitimate=.98)"
    ]
   },
   {
@@ -185,7 +185,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "experiment(data, 100000, fraud=.1, legitimate=.9)"
+    "experiment(data, 1000, fraud=.1, legitimate=.9)"
    ]
   },
   {
@@ -194,7 +194,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "experiment(data, 100000, fraud=.3, legitimate=.7)"
+    "experiment(data, 1000, fraud=.3, legitimate=.7)"
    ]
   },
   {


### PR DESCRIPTION
Metrics are struggling with the higher number of requests. reduced from 10,000 to 1000.